### PR TITLE
Fix for invalid template spec missing image on patch.

### DIFF
--- a/install/argocd-repo-server.patch.yaml
+++ b/install/argocd-repo-server.patch.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       containers:
         - name: argocd-repo-server
+          image: replaced_by_setup 
           volumeMounts:
             - name: custom-tools
               subPath: argocd-cloudtruth-plugin

--- a/install/setup.sh
+++ b/install/setup.sh
@@ -66,7 +66,11 @@ echo "${secret_yaml}" | kubectl apply -n ${ARGO_NAMESPACE} -f -
 kubectl get -n ${ARGO_NAMESPACE} configmap/argocd-cm -o yaml > ${basedir}/argocd-cm..original.$(date +%s).yaml
 kubectl patch -n ${ARGO_NAMESPACE} configmap/argocd-cm --patch "$(echoFile argocd-cm.patch.yaml)"
 
+# Get the current argocd-repo-server image and replace it in the yaml
+ARGOCD_REPO_IMAGE=$(kubectl get -n argocd deployment/argocd-repo-server -o jsonpath="{.spec.template.spec.containers[0].image}")
+argocd_repo_server=$(echoFile argocd-repo-server.patch.yaml | sed "s|image:.*$|image: ${ARGOCD_REPO_IMAGE}|")
+
 kubectl get -n ${ARGO_NAMESPACE} deployment/argocd-repo-server -o yaml > ${basedir}/argocd-repo-server.original.$(date +%s).yaml
-kubectl patch -n ${ARGO_NAMESPACE} deployment/argocd-repo-server --patch "$(echoFile argocd-repo-server.patch.yaml)"
+kubectl patch -n ${ARGO_NAMESPACE} deployment/argocd-repo-server --patch "${argocd_repo_server}"
 
 kubectl rollout restart -n ${ARGO_NAMESPACE} deployment/argocd-repo-server


### PR DESCRIPTION
Fixes invalid template spec for newer k8s versions.
Simple sed of the image: line (added to the template) which grabs it from the current deploy and replaces it in the image so we don't assume image versions.